### PR TITLE
bug fix: 0.e7 should not pass the test

### DIFF
--- a/src/main/java/com/alibaba/fastjson/JSONValidator.java
+++ b/src/main/java/com/alibaba/fastjson/JSONValidator.java
@@ -156,7 +156,10 @@ public abstract class JSONValidator implements Cloneable {
 
                 if (ch == '.') {
                     next();
-
+                    // bug fix: 0.e7 should not pass the test
+                    if (ch < '0' || ch > '9') {
+                        error();
+                    }
                     while (ch >= '0' && ch <= '9') {
                         next();
                     }


### PR DESCRIPTION
If there's a dot, then the next char should be a digit, the original code does not handle such a test case: 
{
	"nums": 0.e-7
}